### PR TITLE
Remove STATICFILES_DIRS from settings

### DIFF
--- a/tracker/settings.py
+++ b/tracker/settings.py
@@ -136,10 +136,6 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "static"),
-]
-
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 ACCOUNT_ACTIVATION_DAYS = 7


### PR DESCRIPTION
to prevent "The STATICFILES_DIRS setting should not contain the
STATIC_ROOT setting" error
